### PR TITLE
Fix test runner path

### DIFF
--- a/logos-vscode/.gitignore
+++ b/logos-vscode/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 out/
+.vscode-test/
 src/**/*.js
 src/**/*.js.map
 !src/panel/webview.js

--- a/logos-vscode/package.json
+++ b/logos-vscode/package.json
@@ -151,7 +151,7 @@
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",
-    "test": "npm run compile && tsc -p ./tsconfig.test.json && node ./out/test/runTest.js",
+    "test": "npm run compile && tsc -p ./tsconfig.test.json && node ./out/test/test/runTest.js",
     "package": "vsce package"
   },
   "devDependencies": {

--- a/logos-vscode/package.json
+++ b/logos-vscode/package.json
@@ -151,7 +151,7 @@
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",
-    "test": "npm run compile && tsc -p ./tsconfig.test.json && node ./out/test/test/runTest.js",
+    "test": "npm run compile && tsc -p ./tsconfig.test.json && node ./scripts/run-tests.js",
     "package": "vsce package"
   },
   "devDependencies": {

--- a/logos-vscode/scripts/run-tests.js
+++ b/logos-vscode/scripts/run-tests.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const testRunner = path.resolve(__dirname, '../out/test/test/runTest.js');
+
+function run(command, args) {
+  const result = spawnSync(command, args, { stdio: 'inherit' });
+  if (result.error) {
+    if (result.error.code === 'ENOENT') {
+      throw new Error(`Unable to find required executable: ${command}`);
+    }
+    throw result.error;
+  }
+  if (typeof result.status === 'number' && result.status !== 0) {
+    process.exit(result.status);
+  }
+}
+
+function hasDisplayServer() {
+  return Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+}
+
+function main() {
+  try {
+    if (process.platform === 'linux' && !hasDisplayServer()) {
+      try {
+        run('xvfb-run', ['-a', 'node', testRunner]);
+        return;
+      } catch (err) {
+        if (err instanceof Error && err.message.includes('xvfb-run')) {
+          console.error(
+            'VS Code integration tests require a display server. Install xvfb (e.g. "sudo apt-get install xvfb") '
+              + 'or run the tests from an environment with DISPLAY configured.'
+          );
+          process.exit(1);
+        }
+        throw err;
+      }
+    }
+
+    run('node', [testRunner]);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/logos-vscode/test/extension.test.ts
+++ b/logos-vscode/test/extension.test.ts
@@ -1,3 +1,4 @@
+import { before, describe, it } from 'mocha';
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { ConfigManager } from '../src/config';
@@ -28,8 +29,8 @@ class MockOllamaClient extends OllamaClient {
   }
 }
 
-suite('Logos Extension', () => {
-  suiteSetup(async () => {
+describe('Logos Extension', () => {
+  before(async () => {
     const extension = vscode.extensions.getExtension('logos-local.logos');
     if (!extension) {
       throw new Error('Extension should exist');
@@ -37,7 +38,7 @@ suite('Logos Extension', () => {
     await extension.activate();
   });
 
-  test('commands are registered', async () => {
+  it('registers commands', async () => {
     const commands = await vscode.commands.getCommands(true);
     assert.ok(commands.includes('logos.reviewSelection'));
     assert.ok(commands.includes('logos.refactorSelection'));
@@ -46,7 +47,7 @@ suite('Logos Extension', () => {
     assert.ok(commands.includes('logos.openChat'));
   });
 
-  test('config manager exposes defaults', () => {
+  it('exposes config defaults', () => {
     const manager = new ConfigManager();
     const config = manager.get();
     assert.strictEqual(config.coderModel, 'qwen2.5-coder:7b');
@@ -54,7 +55,7 @@ suite('Logos Extension', () => {
     assert.strictEqual(config.apiBaseUrl, 'http://localhost:11434');
   });
 
-  test('router delegates to ollama client', async () => {
+  it('routes calls to the Ollama client', async () => {
     const manager = new ConfigManager();
     const client = new MockOllamaClient(manager);
     const router = new LogosRouter(manager, client);
@@ -65,7 +66,7 @@ suite('Logos Extension', () => {
     assert.strictEqual(review.summary, 'ok');
   });
 
-  test('open chat command resolves without error', async () => {
+  it('opens chat command without error', async () => {
     await vscode.commands.executeCommand('logos.openChat');
   });
 });

--- a/logos-vscode/test/index.ts
+++ b/logos-vscode/test/index.ts
@@ -1,0 +1,29 @@
+import * as path from 'path';
+import Mocha from 'mocha';
+import { glob } from 'glob';
+
+export async function run(): Promise<void> {
+  const mocha = new Mocha({
+    ui: 'bdd',
+    color: true,
+    timeout: 10000,
+  });
+
+  const testsRoot = path.resolve(__dirname);
+
+  const files = await glob('**/*.test.js', { cwd: testsRoot });
+
+  for (const file of files) {
+    mocha.addFile(path.resolve(testsRoot, file));
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    mocha.run(failures => {
+      if (failures > 0) {
+        reject(new Error(`${failures} tests failed`));
+      } else {
+        resolve();
+      }
+    });
+  });
+}

--- a/logos-vscode/test/runTest.ts
+++ b/logos-vscode/test/runTest.ts
@@ -3,8 +3,8 @@ import { runTests } from '@vscode/test-electron';
 
 async function main() {
   try {
-    const extensionDevelopmentPath = path.resolve(__dirname, '..');
-    const extensionTestsPath = path.resolve(__dirname, 'extension.test.js');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, 'index.js');
     await runTests({ extensionDevelopmentPath, extensionTestsPath });
   } catch (err) {
     console.error('Failed to run tests', err);


### PR DESCRIPTION
## Summary
- fix the npm test script to execute the compiled VS Code harness from its generated location

## Testing
- npm test *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68cf904c7d388322a215fc2c87ee8ab3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Updated test workflow to use a new test runner script; improved test discovery and execution (including headless/Linux support) and migrated tests to Mocha BDD style with expanded command coverage.

- Chores
  - Added ignore rule to exclude local test runtime artifacts from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->