### PR TITLE
Document Linux prerequisites for npm test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 ## README
 
+### Prerequisites for running integration tests
 
+Running `npm test` invokes the `@vscode/test-electron` runner, which requires several system libraries to be available on Linux. Make sure the following packages are installed before executing the test suite:
+
+- `libatk1.0-0`
+- `libatk-bridge2.0-0`
+- `libgtk-3-0`
+- `libx11-xcb1`
+- `libnss3`
+- `libasound2`
+
+On Debian or Ubuntu you can install them with:
+
+```bash
+sudo apt-get install -y libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 libx11-xcb1 libnss3 libasound2
+```
+
+After installing the dependencies, rerun the integration tests with `npm test` to confirm everything works as expected.


### PR DESCRIPTION
## Summary
- document the Linux system packages required for running `npm test` because it uses `@vscode/test-electron`
- provide an example Debian/Ubuntu installation command and remind contributors to rerun integration tests

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cf926a197483228ee16a1a55a42f92